### PR TITLE
Return :error as first element of tuple instead of :fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ iex> ExRated.check_rate("my-rate-limited-api", 10_000, 5)
 {:ok, 1}
 ```
 
-The `ExRated.check_rate` function will return an `{:ok, Integer}` tuple if its OK to proceed with your rate limited function. The Integer returned is the current value of the incrementing counter showing how many times in the time scale window your function has already been called. If you are over limit a `{:fail, Integer}` tuple will be returned where the Integer is always the limit you have specified in the function call.
+The `ExRated.check_rate` function will return an `{:ok, Integer}` tuple if its OK to proceed with your rate limited function. The Integer returned is the current value of the incrementing counter showing how many times in the time scale window your function has already been called. If you are over limit a `{:error, Integer}` tuple will be returned where the Integer is always the limit you have specified in the function call.
 
 ## Installation
 

--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -45,7 +45,7 @@ defmodule ExRated do
       {:ok, 1}
 
   """
-  @spec check_rate(id::String.t, scale::integer, limit::integer) :: {:ok, count::integer} | {:fail, limit::integer}
+  @spec check_rate(id::String.t, scale::integer, limit::integer) :: {:ok, count::integer} | {:error, limit::integer}
   def check_rate(id, scale, limit) do
     GenServer.call(:ex_rated, {id, scale, limit})
   end
@@ -124,7 +124,7 @@ defmodule ExRated do
         [counter, _, _] = :ets.update_counter(ets_table_name, key, [{2,1},{3,0},{4,1,0, stamp}])
 
         if (counter > limit) do
-          {:fail, limit}
+          {:error, limit}
         else
           {:ok, counter}
         end

--- a/test/ex_rated_test.exs
+++ b/test/ex_rated_test.exs
@@ -22,18 +22,18 @@ defmodule ExRatedServerTest do
   test "returns expected tuples on mix of in-limit and out-of-limit checks" do
     assert {:ok, 1} = ExRated.check_rate("my-bucket", 10_000, 2)
     assert {:ok, 2} = ExRated.check_rate("my-bucket", 10_000, 2)
-    assert {:fail, 2} = ExRated.check_rate("my-bucket", 10_000, 2)
-    assert {:fail, 2} = ExRated.check_rate("my-bucket", 10_000, 2)
+    assert {:error, 2} = ExRated.check_rate("my-bucket", 10_000, 2)
+    assert {:error, 2} = ExRated.check_rate("my-bucket", 10_000, 2)
   end
 
   test "returns expected tuples on 1000ms bucket check with a sleep in the middle" do
     assert {:ok, 1} = ExRated.check_rate("my-bucket", 1000, 2)
     assert {:ok, 2} = ExRated.check_rate("my-bucket", 1000, 2)
-    assert {:fail, 2} = ExRated.check_rate("my-bucket", 1000, 2)
+    assert {:error, 2} = ExRated.check_rate("my-bucket", 1000, 2)
     :timer.sleep 1000
     assert {:ok, 1} = ExRated.check_rate("my-bucket", 1000, 2)
     assert {:ok, 2} = ExRated.check_rate("my-bucket", 1000, 2)
-    assert {:fail, 2} = ExRated.check_rate("my-bucket", 1000, 2)
+    assert {:error, 2} = ExRated.check_rate("my-bucket", 1000, 2)
   end
 
 end


### PR DESCRIPTION
This updates `ExRated.check_rate/3` to return `{:error, limit}` when the rate limit is exceeded, rather than `{:fail, limit}`. Using `:error` as the first key of a returned tuple seems to be a pretty standard Elixir pattern, and it will make it easier to integrate ex_rated with other libraries, like [MonadEx](https://github.com/rob-brown/MonadEx).

If you're using SemVer, this might require a major version bump (i.e. 1.0.0) since this change is not backwards compatible.