### PR TITLE
Add read_rate, incr_rate functions and time_left in milliseconds to the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ iex> ExRated.check_rate("my-rate-limited-api", 10_000, 5)
 The `ExRated.check_rate` function will return an `{:ok, Integer}` tuple if its OK to proceed with your rate limited function. The Integer returned is the current value of the incrementing counter showing how many times in the time scale window your function has already been called. If you are over limit a `{:error, Integer}` tuple will be returned where the Integer is always the limit you have specified in the function call.
 
 
+Call the ExRated application with `ExRated.inspect_bucket/3`.  This function takes the same three arguments as `check_rate`:
+
+For example, if you want to inspect the bucket for your API:
+
+```elixir
+iex> ExRated.inspect_bucket("my-rate-limited-api", 10_000, 5)
+{0, 5, 2483, nil, nil}
+iex> ExRated.check_rate("my-rate-limited-api", 10_000, 5)
+{:ok, 1}
+iex> ExRated.inspect_bucket("my-rate-limited-api", 10_000, 5)
+{1, 4, 723, 1450282268397, 1450282268397}
+```
+
+The `ExRated.inspect_bucket` function will return a `{count, count_remaining, ms_to_next_bucket, created_at, updated_at}` tuple, count and count_remaining are integers, ms_to_next_bucket is the number of milliseconds before the bucket resets, created_at and updated_at are timestamps in millseconds.
+
 Call the ExRated application with `ExRated.delete_bucket/1`.  This function takes one argument:
 
 1. A `bucket name` (String).  You can have as many buckets as you need.

--- a/test/ex_rated_test.exs
+++ b/test/ex_rated_test.exs
@@ -36,6 +36,18 @@ defmodule ExRatedServerTest do
     assert {:error, 2} = ExRated.check_rate("my-bucket", 1000, 2)
   end
 
+  test "returns expected tuples on inspect_bucket" do
+    assert {0, 2, _, nil, nil} = ExRated.inspect_bucket("my-bucket1", 1000, 2)
+    assert {:ok, 1} = ExRated.check_rate("my-bucket1", 1000, 2)
+    assert {1, 1, _, _, _} = ExRated.inspect_bucket("my-bucket1", 1000, 2)
+    assert {:ok, 2} = ExRated.check_rate("my-bucket1", 1000, 2)
+    assert {:ok, 1} = ExRated.check_rate("my-bucket2", 1000, 2)
+    assert {2, 0, _, _, _} = ExRated.inspect_bucket("my-bucket1", 1000, 2)
+    assert {:error, 2} = ExRated.check_rate("my-bucket1", 1000, 2)
+    assert {3, 0, ms_to_next_bucket, _, _} = ExRated.inspect_bucket("my-bucket1", 1000, 2)
+    assert ms_to_next_bucket < 1000
+  end
+
   test "returns expected tuples on delete_bucket" do
     assert {:ok, 1} = ExRated.check_rate("my-bucket1", 1000, 2)
     assert {:ok, 2} = ExRated.check_rate("my-bucket1", 1000, 2)
@@ -49,5 +61,7 @@ defmodule ExRatedServerTest do
 
     assert :error = ExRated.delete_bucket("unknown-bucket")
   end
+
+
 
 end


### PR DESCRIPTION
Add read_rate, incr_rate functions to allow read the current counter without incrementing the counter
Added time_left in milliseconds to the result

Got slightly carried away and added the read_rate, incr_rate functions

Will update the documentation and tests properly if you are happy with the new functions and result