### PR TITLE
switch to automatic application inference

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExRated.Mixfile do
   # cleanup_rate :   cleanup every X milliseconds (60_000, every 1 minute)
   # ets_table_name : the registered name of the ETS table where buckets are stored.
   def application do
-    [applications: [:logger],
+    [extra_applications: [:logger],
      env: [timeout: 90_000_000, cleanup_rate: 60_000, ets_table_name: :ex_rated_buckets],
      mod: {ExRated.App, []}]
   end


### PR DESCRIPTION
While the `:ex2ms` dependency works fine in development, when I create a release using Distillery, the dependency is not found:

```
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :ex2ms

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.
```

Switching to automatic application inference as [explained here](https://elixirforum.com/t/dependencys-dependencies-not-found-in-production/10563/2) and [here](https://github.com/jsonkenl/xlsxir/pull/72) fixes this issue.