### PR TITLE
Avoid Genserver Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,29 @@ You can use ExRated in your projects in two steps:
 You can also start the GenServer manually, and pass it custom config, with something like:
 
 ```elixir
-{:ok, pid} = GenServer.start_link(ExRated, [ {:timeout, 10_000}, {:cleanup_rate, 10_000}, {:ets_table_name, :ex_rated_buckets}, {:persistent, false} ], [name: :ex_rated])
+{:ok, pid} = GenServer.start_link(ExRated, [ {:timeout, 10_000}, {:cleanup_rate, 10_000}, {:persistent, false} ], [name: :ex_rated])
 ```
 
-Where the args and their defaults are:
+Alternatively, you can configure them in your `config/config.exs` (or
+other config) file like
+```
+config :exrated,
+    timeout: 10_000,
+	cleanup_rate: 10_000,
+	persisent: false,
+	name: :ex_rated,
+	ets_table_name: :ets_rated_test_buckets
+```
+
+These args and their defaults are:
 
 `{:timeout, 90_000_000}` : buckets older than this in milliseconds will be automatically pruned.
 
 `{:cleanup_rate, 60_000}` : how often, in milliseconds, the bucket pruning process will be run.
 
-`{:ets_table_name, :ex_rated_buckets}` : The atom name of the ETS table.
+`{:ets_table_name, :ex_rated_buckets}` : The atom name of the ETS
+table.  This can be configured within your `config` files but not when
+starting the GenServer manually.
 
 `{:persistent, false}` : Whether to persist ETS table to disk with DETS on server stop/restart.
 

--- a/bench/test_bench.exs
+++ b/bench/test_bench.exs
@@ -5,7 +5,6 @@ defmodule BasicBench do
       GenServer.start_link(ExRated, [
         {:timeout, 10_000},
         {:cleanup_rate,10_000},
-        {:ets_table_name, :ex_rated_buckets_benchfella},
         {:persistent, false},
       ], [name: :ex_rated])
     end

--- a/test/ex_rated_test.exs
+++ b/test/ex_rated_test.exs
@@ -3,7 +3,7 @@ defmodule ExRatedServerTest do
 
   setup context do
 
-    table = :ex_rated_buckets_test
+    table = Application.get_env(:ex_rated, :ets_table_name, :ex_rated_buckets)
 
     {:ok, pid} = start_server(table, context[:persistent] || false)
 
@@ -116,7 +116,6 @@ defmodule ExRatedServerTest do
     GenServer.start_link(ExRated, [
       {:timeout, 10_000},
       {:cleanup_rate,10_000},
-      {:ets_table_name, table},
       {:persistent, persistent},
     ], [name: :ex_rated])
   end


### PR DESCRIPTION
This avoids passing requests through the GenServer managing the ETS table, instead accessing the table directly, as described in https://github.com/grempe/ex_rated/issues/24.  I believe this shouldn't have negative performance characteristics, since previously the main process would wait for the ETS access anyway, but if there's anything I'm missing in that sense let me know.  I'm also happy to make any other changes that need to happen.

Thanks for reviewing!