### PR TITLE
Matrix tests for Elixir/OTP versions and small refactors.

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,23 +2,105 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev/* ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  build:
-
+  # Refactoring duplicated yaml is currently not possible
+  # because Github does not support anchor syntax (& and *) now.
+  elixir_1_11:
     runs-on: ubuntu-latest
-
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.11.0]
+        otp: [21.0, 22.0, 23.0]
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup elixir
-      uses: actions/setup-elixir@v1
-      with:
-        elixir-version: '1.9.4' # Define the elixir version [required]
-        otp-version: '22.2' # Define the OTP version [required]
-    - name: Install Dependencies
-      run: mix deps.get
-    - name: Run Tests
-      run: mix test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test
+
+  elixir_1_10:
+    runs-on: ubuntu-latest
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.10.0]
+        otp: [21.0, 22.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test
+
+  elixir_1_9:
+    runs-on: ubuntu-latest
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.9.0]
+        otp: [20.0, 21.0, 22.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test
+
+  elixir_1_8:
+    runs-on: ubuntu-latest
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.8.0]
+        otp: [20.0, 21.0, 22.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test
+
+  elixir_1_7:
+    runs-on: ubuntu-latest
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.7.0]
+        otp: [19.0, 20.0, 21.0, 22.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test
+
+  elixir_1_6:
+    runs-on: ubuntu-latest
+    name: Test on Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        elixir: [1.6.0]
+        otp: [19.0, 20.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.otp}}
+      - run: mix deps.get
+      - run: mix test

--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -21,11 +21,8 @@ defmodule ExRated do
   @doc """
   Starts the ExRated rate limit counter server.
   """
-  def start_link(args, opts \\ []) do
-    case args do
-      [] -> GenServer.start_link(__MODULE__, app_args_with_defaults(), opts)
-      _ -> GenServer.start_link(__MODULE__, Keyword.merge(app_args_with_defaults(), args), opts)
-    end
+  def start_link(args \\ [], opts \\ []) do
+    GenServer.start_link(__MODULE__, Keyword.merge(app_args_with_defaults(), args), opts)
   end
 
 

--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -147,7 +147,7 @@ defmodule ExRated do
   end
 
   def handle_cast(_msg, state) do
-    {:reply, state}
+    {:noreply, state}
   end
 
   def handle_info(:prune, state) do

--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -115,6 +115,7 @@ defmodule ExRated do
 
   @doc false
   def init(args) do
+    Process.flag(:trap_exit, true)
     [
       {:timeout, timeout},
       {:cleanup_rate, cleanup_rate},

--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -25,6 +25,11 @@ defmodule ExRated do
     GenServer.start_link(__MODULE__, Keyword.merge(app_args_with_defaults(), args), opts)
   end
 
+  @doc false
+  def child_spec(args_opts) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, args_opts}}
+  end
+
 
   @doc """
   Check if the action you wish to take is within the rate limit bounds
@@ -108,6 +113,7 @@ defmodule ExRated do
 
   ## Server Callbacks
 
+  @doc false
   def init(args) do
     [
       {:timeout, timeout},

--- a/lib/ex_rated_app.ex
+++ b/lib/ex_rated_app.ex
@@ -6,7 +6,7 @@ defmodule ExRated.App do
   def start(_type, _args) do
     children = [
       # Define workers and child supervisors to be supervised
-      %{id: ExRated, start: {ExRated, :start_link, [[], [name: :ex_rated]]}}
+      {ExRated, [[], [name: :ex_rated]]}
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/ex_rated_app.ex
+++ b/lib/ex_rated_app.ex
@@ -4,12 +4,9 @@ defmodule ExRated.App do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
       # Define workers and child supervisors to be supervised
-      # worker(ExRated.Worker, [arg1, arg2, arg3])
-      worker(ExRated, [[], [name: :ex_rated]])
+      %{id: ExRated, start: {ExRated, :start_link, [[], [name: :ex_rated]]}}
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html


### PR DESCRIPTION
* Add matrix tests for Elixir/OTP versions for Elixir >= 1.6.
* Remove deprecated Supervisor.Spec.worker usage.
* Remove `init/1` from generated docs.