### PR TITLE
Fix link in moduledoc

### DIFF
--- a/lib/ex_rated.ex
+++ b/lib/ex_rated.ex
@@ -3,10 +3,8 @@ defmodule ExRated do
 
   @moduledoc """
     An Elixir OTP GenServer that provides the ability to manage rate limiting
-    for any process that needs it.  This rate limiter is based on the
-    concept of a 'token bucket'.  You can read more here:
-
-      http://en.wikipedia.org/wiki/Token_bucket
+    for any process that needs it. This rate limiter is based on the concept 
+    of a 'token bucket' (http://en.wikipedia.org/wiki/Token_bucket).
 
     This application started as a direct port of the Erlang 'raterlimiter' project
     created by Alexander Sorokin (https://github.com/Gromina/raterlimiter,


### PR DESCRIPTION
Makes the link clickable. 

Currently it looks like this:
<img width="1108" alt="Screenshot 2021-01-04 at 19 53 19@2x" src="https://user-images.githubusercontent.com/104180/103568828-8cf09400-4ec6-11eb-8988-ec4940cf67de.png">
