### PR TITLE
Correct the library version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can use ExRated in your projects in two steps:
 
    ```elixir
    def deps do
-     [{:ex_rated, "~> 1.2"}]
+     [{:ex_rated, "~> 2.0"}]
    end
    ```
 


### PR DESCRIPTION
This is a minor improvement so that we can avoid users confusion.

Currently the library version specified in `README.md` is the previous version (v1). A new user may install old version following this instruction. 